### PR TITLE
fix: enable direnv integration by creating windows without commands

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -95,7 +95,7 @@ impl SessionManager {
                     TmuxCommand::new_window(
                         &session_name,
                         &window_name,
-                        None,  // No command - let shell initialize properly
+                        None, // No command - let shell initialize properly
                         Some(&root_path),
                     )?;
                     // Send command after window is created
@@ -109,7 +109,7 @@ impl SessionManager {
                         TmuxCommand::new_window(
                             &session_name,
                             window_name,
-                            None,  // No command - let shell initialize properly
+                            None, // No command - let shell initialize properly
                             Some(&root_path),
                         )?;
                         // Send command after window is created
@@ -124,10 +124,10 @@ impl SessionManager {
                         TmuxCommand::new_window(
                             &session_name,
                             window_name,
-                            None,  // No command - let shell initialize properly
+                            None, // No command - let shell initialize properly
                             Some(&root_path),
                         )?;
-                        
+
                         // Send first pane command if not empty
                         let first_pane = layout_config.panes.first().ok_or_else(|| {
                             TmuxrsError::TmuxError(
@@ -139,7 +139,9 @@ impl SessionManager {
                         }
 
                         // Add additional panes by splitting
-                        for (pane_index, pane_command) in layout_config.panes.iter().skip(1).enumerate() {
+                        for (pane_index, pane_command) in
+                            layout_config.panes.iter().skip(1).enumerate()
+                        {
                             // Create split without command to allow proper shell initialization
                             TmuxCommand::split_window_horizontal(
                                 &session_name,
@@ -151,7 +153,12 @@ impl SessionManager {
                             // Pane indices start at 0, first pane is 0, second is 1, etc.
                             let target_pane_index = pane_index + 1; // +1 because we skipped the first pane
                             if !pane_command.trim().is_empty() {
-                                TmuxCommand::send_keys_to_pane(&session_name, window_name, target_pane_index, pane_command)?;
+                                TmuxCommand::send_keys_to_pane(
+                                    &session_name,
+                                    window_name,
+                                    target_pane_index,
+                                    pane_command,
+                                )?;
                             }
                         }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -91,46 +91,68 @@ impl SessionManager {
             match window_config {
                 crate::config::WindowConfig::Simple(command) => {
                     let window_name = format!("window-{}", index + 1);
+                    // Create window without command to allow proper shell initialization
                     TmuxCommand::new_window(
                         &session_name,
                         &window_name,
-                        Some(command),
+                        None,  // No command - let shell initialize properly
                         Some(&root_path),
                     )?;
+                    // Send command after window is created
+                    if !command.trim().is_empty() {
+                        TmuxCommand::send_keys(&session_name, &window_name, command)?;
+                    }
                 }
                 crate::config::WindowConfig::Complex { window } => {
                     for (window_name, command) in window {
+                        // Create window without command to allow proper shell initialization
                         TmuxCommand::new_window(
                             &session_name,
                             window_name,
-                            Some(command),
+                            None,  // No command - let shell initialize properly
                             Some(&root_path),
                         )?;
+                        // Send command after window is created
+                        if !command.trim().is_empty() {
+                            TmuxCommand::send_keys(&session_name, window_name, command)?;
+                        }
                     }
                 }
                 crate::config::WindowConfig::WithLayout { window } => {
                     for (window_name, layout_config) in window {
-                        // Create the window with the first pane
+                        // Create the window without command to allow proper shell initialization
+                        TmuxCommand::new_window(
+                            &session_name,
+                            window_name,
+                            None,  // No command - let shell initialize properly
+                            Some(&root_path),
+                        )?;
+                        
+                        // Send first pane command if not empty
                         let first_pane = layout_config.panes.first().ok_or_else(|| {
                             TmuxrsError::TmuxError(
                                 "Window layout must have at least one pane".to_string(),
                             )
                         })?;
-                        TmuxCommand::new_window(
-                            &session_name,
-                            window_name,
-                            Some(first_pane),
-                            Some(&root_path),
-                        )?;
+                        if !first_pane.trim().is_empty() {
+                            TmuxCommand::send_keys(&session_name, window_name, first_pane)?;
+                        }
 
                         // Add additional panes by splitting
-                        for pane_command in layout_config.panes.iter().skip(1) {
+                        for (pane_index, pane_command) in layout_config.panes.iter().skip(1).enumerate() {
+                            // Create split without command to allow proper shell initialization
                             TmuxCommand::split_window_horizontal(
                                 &session_name,
                                 window_name,
-                                pane_command,
+                                "", // Empty command - shell will initialize properly
                                 Some(&root_path),
                             )?;
+                            // Send command to the new pane after it's created
+                            // Pane indices start at 0, first pane is 0, second is 1, etc.
+                            let target_pane_index = pane_index + 1; // +1 because we skipped the first pane
+                            if !pane_command.trim().is_empty() {
+                                TmuxCommand::send_keys_to_pane(&session_name, window_name, target_pane_index, pane_command)?;
+                            }
                         }
 
                         // Apply layout if specified

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -132,6 +132,18 @@ impl TmuxCommand {
             .execute()
     }
 
+    /// Send keys to a specific pane
+    #[allow(dead_code)]
+    pub fn send_keys_to_pane(session_name: &str, window_name: &str, pane_index: usize, keys: &str) -> Result<String> {
+        Self::new()
+            .arg("send-keys")
+            .arg("-t")
+            .arg(format!("{session_name}:{window_name}.{pane_index}"))
+            .arg(keys)
+            .arg("Enter")
+            .execute()
+    }
+
     /// Kill a session
     #[allow(dead_code)]
     pub fn kill_session(session_name: &str) -> Result<String> {
@@ -165,7 +177,12 @@ impl TmuxCommand {
             cmd = cmd.arg("-c").arg(dir.to_string_lossy().as_ref());
         }
 
-        cmd.arg(command).execute()
+        // Only add command if not empty - this allows shell to initialize properly
+        if !command.trim().is_empty() {
+            cmd = cmd.arg(command);
+        }
+
+        cmd.execute()
     }
 
     /// Split window vertically (above/below)
@@ -191,7 +208,12 @@ impl TmuxCommand {
             cmd = cmd.arg("-c").arg(dir.to_string_lossy().as_ref());
         }
 
-        cmd.arg(command).execute()
+        // Only add command if not empty - this allows shell to initialize properly
+        if !command.trim().is_empty() {
+            cmd = cmd.arg(command);
+        }
+
+        cmd.execute()
     }
 
     /// Select layout for a window

--- a/src/tmux.rs
+++ b/src/tmux.rs
@@ -134,7 +134,12 @@ impl TmuxCommand {
 
     /// Send keys to a specific pane
     #[allow(dead_code)]
-    pub fn send_keys_to_pane(session_name: &str, window_name: &str, pane_index: usize, keys: &str) -> Result<String> {
+    pub fn send_keys_to_pane(
+        session_name: &str,
+        window_name: &str,
+        pane_index: usize,
+        keys: &str,
+    ) -> Result<String> {
         Self::new()
             .arg("send-keys")
             .arg("-t")


### PR DESCRIPTION
## Summary

Fixes direnv integration issue where `.envrc` files were not being loaded in tmux sessions created by tmuxrs.

- ✅ Enables direnv environment variables in all windows and panes
- ✅ Maintains compatibility with existing tmuxrs configurations  
- ✅ Uses two-step approach: create windows/panes without commands, then send commands after shell initialization

## Root Cause

The issue occurred because tmuxrs was creating windows by passing commands directly to `tmux new-window` and `tmux split-window`. When tmux receives a command argument, it runs that command **instead** of starting an interactive shell, which prevented shell initialization files (`.bashrc`/`.zshrc`) from running and loading direnv hooks.

## Solution

Changed window/pane creation to use a two-step approach:

1. **Create windows/panes WITHOUT commands** - allows normal shell startup and direnv loading
2. **Send commands via `send-keys` AFTER creation** - commands run in the fully initialized shell environment

### Before (broken):
```rust
TmuxCommand::new_window(session, window, Some(command), path)?;
```

### After (fixed):
```rust
TmuxCommand::new_window(session, window, None, path)?;  // No command
if !command.trim().is_empty() {
    TmuxCommand::send_keys(session, window, command)?;  // Send after
}
```

## Changes Made

- **Windows**: Create without commands, send commands via `send_keys` after creation
- **Split Panes**: Create without commands, send commands via `send_keys_to_pane` after creation  
- **New Method**: Added `send_keys_to_pane` for targeting specific panes using `session:window.pane_index` format
- **Empty Command Handling**: Updated split window methods to handle empty commands properly

## Test Results

Tested with `.envrc` containing `export DIRENV_TEST="SUCCESS_FROM_ENVRC"`:

**Result**: Environment variables now load correctly in all windows and panes ✅

```
=== Window: server ===
DIRENV_TEST=SUCCESS_FROM_ENVRC

=== Window: test (split panes) ===  
Interactive second: DIRENV_TEST=SUCCESS_FROM_ENVRC
```

## Testing

- ✅ All existing tests pass
- ✅ Pre-commit hooks pass (formatting, clippy, tests)
- ✅ Manual testing confirms direnv works in windows and split panes
- ✅ Backwards compatible with existing configurations

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)