### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-01-06
+
+### Fixed
+- **Shell initialization** - Fixed direnv and shell environment inheritance in tmux sessions (#4)
+  - Windows and panes now properly initialize shells before running commands
+  - Shell hooks (like direnv) now work correctly in all windows and split panes
+  - Environment variables are properly inherited from the parent shell
+
+### Added
+- **Shell interaction tests** - Comprehensive integration tests for shell initialization (#6)
+- **Robust path expansion** - Added shellexpand library for proper tilde expansion in paths (#3)
+
+### Changed
+- **Window creation behavior** - Modified to create windows without commands first, then send commands via send-keys
+- **Split pane creation** - Extended shell initialization fix to split panes
+
 ## [0.1.0] - 2024-06-28
 
 ### Added
@@ -38,5 +54,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Platforms**: Linux, macOS, Windows (where tmux is available)
 - **License**: MIT OR Apache-2.0
 
-[Unreleased]: https://github.com/beijaflor/tmuxrs/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/beijaflor/tmuxrs/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/beijaflor/tmuxrs/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/beijaflor/tmuxrs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "tmuxrs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmuxrs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["shootani <sho.otani@gmail.com>"]
 description = "A modern, Rust-based tmux session manager with centralized configuration and directory-aware execution. Drop-in replacement for tmuxinator."


### PR DESCRIPTION
## Release v0.1.1

This release includes important bug fixes and improvements for shell environment handling.

### 🐛 Bug Fixes
- **Fixed shell initialization issues** (#4, #5) - tmuxrs now properly initializes shells before running commands, ensuring tools like direnv work correctly
- **Fixed split pane shell initialization** - Extended the shell initialization fix to work with split panes

### ✨ Features
- **Robust path expansion** (#3) - Added shellexpand library for proper tilde expansion in paths
- **Comprehensive shell interaction tests** (#6) - Added integration tests to validate shell initialization behavior

### 📋 Changes Summary
- Update version from 0.1.0 to 0.1.1
- Update CHANGELOG.md with release notes
- Update Cargo.lock

### 🔍 Technical Details
The main fix involves changing how tmuxrs creates windows and panes:
- Previously: Commands were passed directly to tmux when creating windows/panes
- Now: Windows/panes are created first without commands, then commands are sent via `send-keys`

This ensures shells start in interactive mode and can properly initialize their environment, including running shell hooks like direnv.

### 📦 After Merge
Once this PR is merged, we can:
1. Create a git tag `v0.1.1`
2. Create a GitHub release
3. Publish to crates.io

🤖 Generated with [Claude Code](https://claude.ai/code)