### PR TITLE
Fix git hooks: Pre-commit formatting workflow leaves unstaged changes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,13 +4,28 @@ set -eu
 
 echo "Running pre-commit checks..."
 
-# Check formatting
+# Stash unstaged changes to preserve developer's work
+stash_name="pre-commit-stash-$$"
+git stash push -k -u -m "$stash_name" >/dev/null || true
+
+# Cleanup function to restore stash on any exit
+cleanup_stash() {
+    if git stash list | grep -q "$stash_name"; then
+        git stash pop --quiet >/dev/null || true
+    fi
+}
+
+# Set up EXIT trap to ensure stash is always restored
+trap cleanup_stash EXIT
+
+# Check formatting and auto-fix if needed
 echo "Checking code formatting..."
 if ! cargo fmt -- --check
 then
-    echo "❌ Code formatting issues detected!"
-    echo "Run 'cargo fmt' to fix formatting issues."
-    exit 1
+    echo "Auto-fixing code formatting..."
+    cargo fmt
+    git add -u  # Stage formatting fixes
+    echo "✅ Code formatting fixed and staged"
 fi
 
 # Run clippy


### PR DESCRIPTION
## Summary

This PR implements a stash/pop pattern in the pre-commit hook to automatically include formatting fixes in commits, resolving the workflow friction described in issue #20.

**Key changes:**
- Auto-fix formatting issues and stage them during pre-commit
- Preserve developer's unstaged changes via git stash
- Maintain existing clippy and test validation

## Problem Solved

The previous workflow caused developer confusion:
1. Developer commits → Hook fails on formatting → Developer runs `cargo fmt`
2. Developer commits again → Hook passes but formatting changes remain unstaged  
3. Developer sees confusing "not committed code changes" that are only formatting

## Solution

**New pre-commit hook flow:**
1. **Stash unstaged changes** to preserve developer's work
2. **Auto-fix formatting** when `cargo fmt --check` fails and stage the fixes
3. **Continue with clippy and tests** as before
4. **Restore stash on exit** (success or failure) via EXIT trap

## Benefits

- ✅ Formatting fixes automatically included in commit
- ✅ Developer's unstaged changes preserved regardless of outcome  
- ✅ No more post-commit formatting change surprises
- ✅ Maintains existing clippy and test validation
- ✅ Robust error handling with `set -eu`

## Test Plan

- [x] Tested hook with staging formatting issues - automatically fixes and stages them
- [x] Verified unstaged changes are preserved via stash/pop mechanism
- [x] Confirmed hook still enforces clippy and test requirements
- [x] Validated EXIT trap properly restores stash on both success and failure

**Note:** Updated to branch from `main` instead of `fix/nested-shell-issue` for cleaner PR history.

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)